### PR TITLE
Created .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.yy linguist-language=GML


### PR DESCRIPTION
Created .gitattributes file to fix GameMaker's ".yy" files being mislabeled as "Yacc", this is to aid in consistency between GML based repositories where applicable 